### PR TITLE
Unify Chrome and Firefox extensions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,19 +23,11 @@
     }
   ],
   "permissions": [
-    "*://*",
+    "*://*/*",
     "https://postwoman.io/",
     "https://postwoman.io/*",
     "https://postwoman.netlify.com/*",
     "https://postwoman.netlify.com/"
   ],
-  "externally_connectable": {
-    "matches": [
-      "http://localhost:3000/*", 
-      "https://postwoman.io/*", 
-      "http://postwoman.io/*", 
-      "https://postwoman.netlify.com/*"
-    ]
-  },
   "manifest_version": 2
 }

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,7 +1,64 @@
-const extensionDetectionEl = document.createElement("span");
-extensionDetectionEl.id = "chromePWExtensionDetect";
+window.addEventListener('message', ev => {
+  if (ev.source !== window || !ev.data) {
+    return;
+  }
 
-document.body.append(extensionDetectionEl);
+  if (ev.data.type === '__POSTWOMAN_EXTENSION_REQUEST__') {
+    chrome.runtime.sendMessage({
+      messageType: "send-req",
+      data: ev.data.config
+    }, (message) => {
+      if (message.data.error) {
+        window.postMessage({
+          type: '__POSTWOMAN_EXTENSION_ERROR__',
+          error: message.data.error
+        }, '*');
+      } else {
+        window.postMessage({
+          type: '__POSTWOMAN_EXTENSION_RESPONSE__',
+          response: message.data.response
+        }, '*');
+      }
+    })
+  }
+});
 
-console.log("Connected to the Postwoman Chrome Extension!");
+const script = document.createElement('script');
+script.textContent = `
+  window.__POSTWOMAN_EXTENSION_HOOK__ = {
+    sendRequest: (config) => new Promise((resolve, reject) => {
+      function handleMessage(ev) {
+        if (ev.source !== window || !ev.data) {
+          return;
+        }
 
+        if (ev.data.type === '__POSTWOMAN_EXTENSION_RESPONSE__') {
+          resolve(ev.data.response);
+          window.removeEventListener('message', handleMessage);
+        } else if (ev.data.type === '__POSTWOMAN_EXTENSION_ERROR__') {
+          const error = ev.data.error;
+
+          // We're restoring the original Error object here
+          const e = new Error(error.message, error.fileName, error.lineNumber);
+          e.name = error.name;
+          e.stack = error.stack;
+          if (error.response) {
+            e.response = error.response;
+          }
+          reject(e);
+          window.removeEventListener('message', handleMessage);
+        }
+      }
+
+      window.addEventListener('message', handleMessage);
+
+      window.postMessage({
+        type: '__POSTWOMAN_EXTENSION_REQUEST__',
+        config
+      }, '*');
+    })
+  }
+`;
+
+document.documentElement.appendChild(script);
+script.parentNode.removeChild(script);


### PR DESCRIPTION
This unifies the Chome and Firefox extensions into one, based on the Chrome extension.

The general idea is to inject a method into the page which uses `window.postMessage` to communicate with the content script. This forwards the request to the background script.
This approach works in Chrome **and** Firefox while communicating with content script directly from the page doesn't work in Firefox.
This is based on https://github.com/facebook/react/blob/08c1f79e1e13719ae2b79240bbd8f97178ddd791/packages/react-devtools-extensions/src/injectGlobalHook.js#L26-L62 from the React DevTools.

This PR also fixes an issue with error objects not being transferred correctly to Postwoman.
Especially with Axios error messages the `response` property wasn't transferred at all, breaking the UX of Postwoman.

Please let me know what to do with that version request. What was the reason behind it? Should it stay?

ref liyasthomas/postwoman#573